### PR TITLE
Make count contextual

### DIFF
--- a/lib/atom-word-count-view.coffee
+++ b/lib/atom-word-count-view.coffee
@@ -33,3 +33,6 @@ class AtomWordCountView extends View
         <p>Words: #{wordCount}</p>")
 
       atom.workspaceView.append(this)
+
+      editor.onDidChange =>
+        @detach()

--- a/lib/atom-word-count-view.coffee
+++ b/lib/atom-word-count-view.coffee
@@ -21,10 +21,15 @@ class AtomWordCountView extends View
       @detach()
     else
       editor = @editorView.editor
-      lines = editor.buffer.lines.length
-      words = editor.buffer.cachedText.split(/\s+/)
-      wordCount = words.length
 
-      @find('.message').html("<p>Lines: #{lines}</p><p>Words: #{wordCount}</p>")
+      text = editor.getSelectedText()
+      text = editor.getText() if text.length == 0
+
+      lineCount = text.split(/\n/).length
+      wordCount = text.split(/\s+/).length
+
+      @find('.message').html("
+        <p>Lines: #{lineCount}</p>
+        <p>Words: #{wordCount}</p>")
 
       atom.workspaceView.append(this)


### PR DESCRIPTION
This pull request makes the word/line count contextual:

```
* if text is selected count the selection
* if no selected text, count the entire document
```

It also detaches the AtomWordCountView when the editor receives changes. This makes it so you can hit Cmd-C, see the count, and keep typing without y
our hands having to leave the keyboard.
